### PR TITLE
Recover home description

### DIFF
--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -1,6 +1,9 @@
 ---
 layout: default
 ---
+<p>{{ page.description_1 | markdownify }}</p>
+<p>{{ page.description_2 | markdownify }}</p>
+
 <div class='projects'>
   <h2>{{ page.projects_title }}</h2>
 


### PR DESCRIPTION
Here we lost home description and nobody notice it :scream: 
https://github.com/coopdevs/coopdevs.github.io/commit/75790c057c2739daf41722a736309c9ba0334b41#diff-822e9cf54ee310f9a7ebd0d16c9ae066

![fireshot capture 100 - coopdevs - http___coopdevs org_es](https://user-images.githubusercontent.com/2297137/43273304-6a9e5570-90fc-11e8-8852-f565d9f8c80e.png)

Sorry was me... Now it's restored :wink: 

![fireshot capture 101 - coopdevs - http___localhost_4000_ca](https://user-images.githubusercontent.com/2297137/43273311-6ca2bfdc-90fc-11e8-962a-7aa2b3698c05.png)


