### PR TITLE
Narrow blog layout to a more legible ~700px

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -15,7 +15,9 @@ footer {
 }
 
 #main-blog {
-  padding-top: 3rem;
+  padding: 3rem 20px 0;
+  max-width: 700px;
+  margin: 0 auto;
 
   img, .video {
     max-width: 90%;


### PR DESCRIPTION
Solves #30 

The grid we use throughout the site leads to way too wide texts which seriously affects the readability of our blog posts. This change sets a max-width to fix it.

## Large

![screenshot from 2018-12-12 17-52-01](https://user-images.githubusercontent.com/762088/49885078-a5e90100-fe36-11e8-85ae-1595cd66b635.png)


## Medium

![screenshot from 2018-12-12 17-51-34](https://user-images.githubusercontent.com/762088/49885042-95d12180-fe36-11e8-85d6-558a5e10f8bc.png)


## Mobile

![screenshot from 2018-12-12 17-52-38](https://user-images.githubusercontent.com/762088/49885110-bbf6c180-fe36-11e8-98fe-c339e5cd8edb.png)
