### PR TITLE
Continuous deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,22 @@
+# Ruby CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-ruby/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/ruby:2.6.3-node-browsers
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/postgres:9.4
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+      - run: bundle install
+      - run: yarn install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,3 +20,27 @@ jobs:
       - checkout
       - run: bundle install
       - run: yarn install
+
+  deploy:
+    machine:
+      enabled: true
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+      - run:
+          name: deploy
+          command: ./deploy
+
+workflows:
+  version: 2
+  build-and-deploy:
+    jobs:
+      - build
+      - deploy:
+          requires:
+            - build
+          filters:
+            branches:
+              only: develop


### PR DESCRIPTION
The build job installs all dependencies and only checks that building the Jekyll site works. Then the deploy job will build it again as it's one of the tasks the ./deploy script performs.