### PR TITLE
Install dependencies & add git attrs in CI deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,10 @@ jobs:
 
     steps:
       - checkout
+      - run: bundle install
+      - run: yarn install
+      - run: git config user.email "saulopefa@gmail.com"
+      - run: git config user.name "Pau Perez"
       - run:
           name: deploy
           command: ./deploy


### PR DESCRIPTION
Otherwise the deployment fails with

```
./deploy
Cloning into '_site'...
remote: Enumerating objects: 44, done.        
remote: Counting objects: 100% (44/44), done.        
remote: Compressing objects: 100% (27/27), done.        
remote: Total 1513 (delta 21), reused 28 (delta 15), pack-reused 1469        
Receiving objects: 100% (1513/1513), 16.68 MiB | 52.88 MiB/s, done.
Resolving deltas: 100% (787/787), done.
bundler: command not found: jekyll
Install missing gem executables with `bundle install`

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: empty ident name (for <circleci@default-7206bf5f-cb09-4d5e-857f-91a2faf98168.c.circleci-picard-mahmood.internal>) not allowed
ERROR: The key you are authenticating with has been marked as read only.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
Exited with code 128
```