### PR TITLE
fix(homepage): removes the hyphen from homepages and the 404 page (reference #76)

### DIFF
--- a/es/404.html
+++ b/es/404.html
@@ -4,7 +4,7 @@
   <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <title>Coopdevs - </title>
+  <title>Coopdevs </title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <link href="https://fonts.googleapis.com/css?family=Lato|Work+Sans" rel="stylesheet" />

--- a/es/index.html
+++ b/es/index.html
@@ -4,7 +4,7 @@
   <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <title>Coopdevs - </title>
+  <title>Coopdevs </title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <link href="https://fonts.googleapis.com/css?family=Lato:400,700,900&display=swap" rel="stylesheet" />

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <title>Coopdevs - </title>
+  <title>Coopdevs </title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <link href="https://fonts.googleapis.com/css?family=Lato:400,700,900&display=swap" rel="stylesheet" />


### PR DESCRIPTION
# What I did

- Removed the `-` from Homepage (both languages)
- Removed the `-` from the 404 page

# How I did it

- Checked out `master` branch
- Fixed the code
- Profit

# How to verify it

- Run `jekyll`
 
# A picture of a cute animal
![animal-967657_640](https://user-images.githubusercontent.com/87614/66121199-893fd480-e5d4-11e9-8ea9-53b723621336.jpg)

Fixes #76 
