### PR TITLE
Have a single head include extracting <link> tags

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,14 +1,8 @@
-<head>
-  <meta charset="utf-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <title>{{ site.title }}{% if page.title %} - {{ page.title }}{% endif %}</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<title>{{ site.title }}{% if page.title %} - {{ page.title }}{% endif %}</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <link href="https://fonts.googleapis.com/css?family=Lato|Work+Sans" rel="stylesheet" />
-  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/css/bootstrap.min.css">
-  <link rel="stylesheet" href='{{ "/assets/css/main.css" | prepend:site.baseurl }}'>
-
-  {% if jekyll.environment == "development" %}
-    <script src="http://localhost:35729/livereload.js"></script>
-  {% endif %}
-</head>
+{% if jekyll.environment == "development" %}
+  <script src="http://localhost:35729/livereload.js"></script>
+{% endif %}

--- a/_includes/head.new.html
+++ b/_includes/head.new.html
@@ -1,13 +1,8 @@
-<head>
-  <meta charset="utf-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <title>{{ site.title }}{% if page.title %} - {{ page.title }}{% endif %}</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<title>{{ site.title }}{% if page.title %} - {{ page.title }}{% endif %}</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <link href="https://fonts.googleapis.com/css?family=Lato:400,700,900&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href='{{ "/css/site.css" | prepend:site.baseurl }}'>
-
-  {% if jekyll.environment == "development" %}
-    <script src="http://localhost:35729/livereload.js"></script>
-  {% endif %}
-</head>
+{% if jekyll.environment == "development" %}
+  <script src="http://localhost:35729/livereload.js"></script>
+{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,7 +1,14 @@
 <!DOCTYPE html>
 
 <html lang="{{ page.lang | default: site.lang | default: "es" }}">
-  {% include head.html %}
+  <head>
+    {% include head.html %}
+
+    <link href="https://fonts.googleapis.com/css?family=Lato|Work+Sans" rel="stylesheet" />
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/css/bootstrap.min.css">
+    <link rel="stylesheet" href='{{ "/assets/css/main.css" | prepend:site.baseurl }}'>
+  </head>
+
   <body>
     <nav class='nav navbar navbar-expand flex-row-reverse'>
       {% include language_switcher.html %}

--- a/_layouts/default.new.html
+++ b/_layouts/default.new.html
@@ -1,7 +1,13 @@
 <!DOCTYPE html>
 
 <html lang="{{ page.lang | default: site.lang | default: "es" }}">
-  {% include head.new.html %}
+  <head>
+    {% include head.html %}
+
+    <link href="https://fonts.googleapis.com/css?family=Lato:400,700,900&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href='{{ "/css/site.css" | prepend:site.baseurl }}'>
+  </head>
+
   <body class="flex flex-col min-h-screen">
     <div class="flex-1 mx-8">
       <div class="my-8 max-w-4xl mx-auto md:my-10">


### PR DESCRIPTION
The <link> tags the two layouts depend on are moved to each layout file so that we don't need to maintain two _includes/head.html that are almost identical. `#refactor`