### PR TITLE
Use Lato in service cards as well

### DIFF
--- a/_includes/service_card.html
+++ b/_includes/service_card.html
@@ -13,9 +13,9 @@
 {% capture text_entry %}
   <div class="{{- margin -}}">
     <h3 class="font-sans text-2xl text-gray-700 font-bold mb-5">{% t include.header %}</h3>
-    <p class="text-gray-400 text-lg">{% t include.content %} </p>
+    <p class="font-sans text-gray-400 text-lg">{% t include.content %} </p>
     <div class="mt-2">
-      <a class="text-blue-500 text-lg" href="{{ include.href }}">{% t include.link_text %} </a>
+      <a class="font-sans text-blue-500 text-lg" href="{{ include.href }}">{% t include.link_text %} </a>
     </div>
   </div>
 {% endcapture %}


### PR DESCRIPTION
If this happens with `<p>` and `<a>` elsewhere we'll need to consider extracting them as includes as if they were React components.