### PR TITLE
Run `jekyll doctor` in CI to spot issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ jobs:
       - checkout
       - run: bundle install
       - run: yarn install
+      - run: bundle exec jekyll doctor
 
   deploy:
     docker:


### PR DESCRIPTION
According to Jekyll docs:

> Outputs any deprecation or configuration issues

We need to realize as soon as possible of any of the two.