### PR TITLE
Add Open Graph metadata to blog post to improve social share

### DIFF
--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -7,5 +7,5 @@
 {% endif %} 
 
 {% if page.cover-photo %}
-<meta property="og:image" content="{{ page.cover - photo }}" />
+<meta property="og:image" content="{{ page.cover-photo }}" />
 {% endif %}

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -1,0 +1,7 @@
+{% if page.title %}
+<meta property="og:title" content="{{ page.title }}" />
+{% endif %} {% if page.description %}
+<meta property="og:description" content="{{ page.description }}" />
+{% endif %} {% if page.cover-photo %}
+<meta property="og:image" content="{{ page.cover - photo }}" />
+{% endif %}

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -1,7 +1,11 @@
 {% if page.title %}
 <meta property="og:title" content="{{ page.title }}" />
-{% endif %} {% if page.description %}
+{% endif %} 
+
+{% if page.description %}
 <meta property="og:description" content="{{ page.description }}" />
-{% endif %} {% if page.cover-photo %}
+{% endif %} 
+
+{% if page.cover-photo %}
 <meta property="og:image" content="{{ page.cover - photo }}" />
 {% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,9 +4,7 @@
   <head>
     {% include head.html %}
 
-    <meta property="og:title" content="{{ page.title }}" />
-    <meta property="og:description" content="{{ page.description }}" />
-    <meta property="og:image" content="{{ page.cover-photo }}" />
+    {% include meta.html %}
 
     <link href="https://fonts.googleapis.com/css?family=Lato|Work+Sans" rel="stylesheet" />
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/css/bootstrap.min.css">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,6 +4,10 @@
   <head>
     {% include head.html %}
 
+    <meta property="og:title" content="{{ page.title }}" />
+    <meta property="og:description" content="{{ page.description }}" />
+    <meta property="og:image" content="{{ page.cover-photo }}" />
+
     <link href="https://fonts.googleapis.com/css?family=Lato|Work+Sans" rel="stylesheet" />
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/css/bootstrap.min.css">
     <link rel="stylesheet" href='{{ "/assets/css/main.css" | prepend:site.baseurl }}'>


### PR DESCRIPTION
#### What does this PR do?
- Add Open Graph metadata to blog post to improve social share
#### Description of Task to be completed?
- In order to show correct snippet in social shares we want to use Open Graph metatags in Post show:
```
<meta property="og:title" content="Post title" />
<meta property="og:description" content="The first characters of Post" />
<meta property="og:image" content="URL of first image in Post" />
```
#### Any background context you want to provide?
- Most content is shared to Facebook as a URL, so it's important that you mark up your website with Open Graph tags to take control over how your content appears on Facebook 

@sseerrggii  This PR aims to fix #15, I have doubts with the values in the `content` attribute which is partially because I couldn't test this out because of the limitation of my pc and also I felt the content are supposed to be dynamic/changing with different post as opposed to them being static. Please review and give feedback 