### PR TITLE
82 -circleci-cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,12 +111,3 @@ workflows:
           <<: *develop_branch_filter
           requires:
             - build
-  # Deploy master branch to production environment
-  production:
-    jobs:
-      - build:
-          <<: *master_branch_filter
-      - deploy:
-          <<: *master_branch_filter
-          requires:
-            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,25 +19,25 @@ aliases:
         fingerprints:
           - "f6:8f:6b:93:bf:a3:a1:52:46:c6:2b:54:b6:5c:2e:23"
   - &restore_bundler_cache
-    - restore_bundler_cache:
-        key: gem-cache-v1-{{ checksum "Gemfile.lock" }}
+    restore_bundler_cache:
+      key: gem-cache-v1-{{ checksum "Gemfile.lock" }}
   - &bundle_install
     run: bundle install
   - &save_bundler_cache
-    - save_bundler_cache:
-        key: gem-cache-v1-{{ checksum "Gemfile.lock" }}
-        paths:
-          - vendor/bundle
+    save_bundler_cache:
+      key: gem-cache-v1-{{ checksum "Gemfile.lock" }}
+      paths:
+        - vendor/bundle
   - &restore_yarn_cache
-    - restore_yarn_cache:
-        key: yarn-cache-{{ checksum "yarn.lock" }}
+    restore_yarn_cache:
+      key: yarn-cache-{{ checksum "yarn.lock" }}
   - &yarn_install
     run: yarn install
   - &save_yarn_cache
-    - save_yarn_cache:
-        key: yarn-cache-{{ checksum "yarn.lock" }}
-        paths:
-          - node_modules
+    save_yarn_cache:
+      key: yarn-cache-{{ checksum "yarn.lock" }}
+      paths:
+        - node_modules
   - &jekyll_doctor
     run: bundle exec jekyll doctor
   - &master_branch_filter

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,28 +19,25 @@ aliases:
         fingerprints:
           - "f6:8f:6b:93:bf:a3:a1:52:46:c6:2b:54:b6:5c:2e:23"
   - &restore_bundler_cache
-    restore_bundler_cache:
-      keys:
-        - gem-cache-v1-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
-        - gem-cache-v1-{{ arch }}-{{ .Branch }}
-        - gem-cache-v1
+    - restore_bundler_cache:
+        key: gem-cache-v1-{{ checksum "Gemfile.lock" }}
   - &bundle_install
     run: bundle install
   - &save_bundler_cache
-    save_bundler_cache:
-      key: gem-cache-v1-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
-      paths:
-        - vendor/bundle
+    - save_bundler_cache:
+        key: gem-cache-v1-{{ checksum "Gemfile.lock" }}
+        paths:
+          - vendor/bundle
   - &restore_yarn_cache
-    restore_yarn_cache:
-      key: yarn-cache-{{ checksum "yarn.lock" }}
+    - restore_yarn_cache:
+        key: yarn-cache-{{ checksum "yarn.lock" }}
   - &yarn_install
     run: yarn install
   - &save_yarn_cache
-    save_yarn_cache:
-      key: yarn-cache-{{ checksum "yarn.lock" }}
-      paths:
-        - node_modules
+    - save_yarn_cache:
+        key: yarn-cache-{{ checksum "yarn.lock" }}
+        paths:
+          - node_modules
   - &jekyll_doctor
     run: bundle exec jekyll doctor
   - &master_branch_filter

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,6 @@ workflows:
       - build:
           <<: *develop_branch_filter
       - deploy:
-          context: develop
           <<: *develop_branch_filter
           requires:
             - build
@@ -118,7 +117,6 @@ workflows:
       - build:
           <<: *master_branch_filter
       - deploy:
-          context: production
           <<: *master_branch_filter
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,16 @@ jobs:
 
     steps:
       - checkout
+      - restore_bundler_cache:
+          keys:
+            - gem-cache-v1-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+            - gem-cache-v1-{{ arch }}-{{ .Branch }}
+            - gem-cache-v1
       - run: bundle install
+      - save_bundler_cache:
+          key: gem-cache-v1-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+          paths:
+            - vendor/bundle
       - run: yarn install
       - run: bundle exec jekyll doctor
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,26 +13,26 @@ aliases:
   - &deploy
     run: ./deploy
   - &git_config_l
-    run: 
+    run: git config -l
   - &add_ssh_keys
     - add_ssh_keys:
         fingerprints:
           - "f6:8f:6b:93:bf:a3:a1:52:46:c6:2b:54:b6:5c:2e:23"
   - &restore_bundler_cache
-    - restore_bundler_cache:
-        keys:
-          - gem-cache-v1-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
-          - gem-cache-v1-{{ arch }}-{{ .Branch }}
-          - gem-cache-v1
+    restore_bundler_cache:
+      keys:
+        - gem-cache-v1-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+        - gem-cache-v1-{{ arch }}-{{ .Branch }}
+        - gem-cache-v1
   - &bundle_install
-    - run: bundle install
+    run: bundle install
   - &save_bundler_cache
-    - save_bundler_cache:
-        key: gem-cache-v1-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
-        paths:
-          - vendor/bundle
+    save_bundler_cache:
+      key: gem-cache-v1-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+      paths:
+        - vendor/bundle
   - &restore_yarn_cache
-    - restore_yarn_cache:
+    restore_yarn_cache:
       key: yarn-cache-{{ checksum "yarn.lock" }}
   - &yarn_install
     run: yarn install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
       - *save_bundler_cache
       - *restore_yarn_cache
       - *yarn_install
-      - *restore_yarn_cache
+      - *save_yarn_cache
       - *git_config
       - *add_ssh_keys
       - *git_config_l

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,9 +15,9 @@ aliases:
   - &git_config_l
     run: git config -l
   - &add_ssh_keys
-    - add_ssh_keys:
-        fingerprints:
-          - "f6:8f:6b:93:bf:a3:a1:52:46:c6:2b:54:b6:5c:2e:23"
+    add_ssh_keys:
+      fingerprints:
+        - "f6:8f:6b:93:bf:a3:a1:52:46:c6:2b:54:b6:5c:2e:23"
   - &restore_bundler_cache
     restore_bundler_cache:
       key: gem-cache-v1-{{ checksum "Gemfile.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,58 @@
 # Check https://circleci.com/docs/2.0/language-ruby/ for more details
 #
 version: 2
+aliases:
+  - &git_config
+    run:
+      name: git config settings
+      command: | 
+        git config --global user.email "ci-build@coopdevs.org"
+        git config --global user.name "CI"
+  - &deploy
+    run: ./deploy
+  - &git_config_l
+    run: 
+  - &add_ssh_keys
+    - add_ssh_keys:
+        fingerprints:
+          - "f6:8f:6b:93:bf:a3:a1:52:46:c6:2b:54:b6:5c:2e:23"
+  - &restore_bundler_cache
+    - restore_bundler_cache:
+        keys:
+          - gem-cache-v1-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+          - gem-cache-v1-{{ arch }}-{{ .Branch }}
+          - gem-cache-v1
+  - &bundle_install
+    - run: bundle install
+  - &save_bundler_cache
+    - save_bundler_cache:
+        key: gem-cache-v1-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+        paths:
+          - vendor/bundle
+  - &restore_yarn_cache
+    - restore_yarn_cache:
+      key: yarn-cache-{{ checksum "yarn.lock" }}
+  - &yarn_install
+    run: yarn install
+  - &save_yarn_cache
+    save_yarn_cache:
+      key: yarn-cache-{{ checksum "yarn.lock" }}
+      paths:
+        - node_modules
+  - &jekyll_doctor
+    run: bundle exec jekyll doctor
+  - &master_branch_filter
+    filters:
+      branches:
+        only: /^master/
+  - &develop_branch_filter
+    filters:
+      branches:
+        only: /^develop/
+  - &feature_branch_filter
+    filters:
+      branches:
+        ignore: /^(master|develop)/
 jobs:
   build:
     docker:
@@ -17,18 +69,13 @@ jobs:
 
     steps:
       - checkout
-      - restore_bundler_cache:
-          keys:
-            - gem-cache-v1-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
-            - gem-cache-v1-{{ arch }}-{{ .Branch }}
-            - gem-cache-v1
-      - run: bundle install
-      - save_bundler_cache:
-          key: gem-cache-v1-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
-          paths:
-            - vendor/bundle
-      - run: yarn install
-      - run: bundle exec jekyll doctor
+      - *restore_bundler_cache
+      - *bundle_install
+      - *save_bundler_cache
+      - *restore_yarn_cache
+      - *yarn_install
+      - *save_yarn_cache
+      - *jekyll_doctor
 
   deploy:
     docker:
@@ -40,24 +87,41 @@ jobs:
 
     steps:
       - checkout
-      - run: bundle install
-      - run: yarn install
-      - run: git config --global user.email "ci-build@coopdevs.org"
-      - run: git config --global user.name "CI"
-      - add_ssh_keys:
-          fingerprints:
-            - "f6:8f:6b:93:bf:a3:a1:52:46:c6:2b:54:b6:5c:2e:23"
-      - run: git config -l
-      - run: ./deploy
+      - *restore_bundler_cache
+      - *bundle_install
+      - *save_bundler_cache
+      - *restore_yarn_cache
+      - *yarn_install
+      - *restore_yarn_cache
+      - *git_config
+      - *add_ssh_keys
+      - *git_config_l
+      - *deploy
+
 
 workflows:
   version: 2
-  build-and-deploy:
+
+  feature:
     jobs:
-      - build
+      - build:
+          <<: *feature_branch_filter
+  develop:
+    jobs:
+      - build:
+          <<: *develop_branch_filter
       - deploy:
+          context: develop
+          <<: *develop_branch_filter
           requires:
             - build
-          filters:
-            branches:
-              only: develop
+  # Deploy master branch to production environment
+  production:
+    jobs:
+      - build:
+          <<: *master_branch_filter
+      - deploy:
+          context: production
+          <<: *master_branch_filter
+          requires:
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,22 +19,22 @@ aliases:
       fingerprints:
         - "f6:8f:6b:93:bf:a3:a1:52:46:c6:2b:54:b6:5c:2e:23"
   - &restore_bundler_cache
-    restore_bundler_cache:
+    restore_cache:
       key: gem-cache-v1-{{ checksum "Gemfile.lock" }}
   - &bundle_install
     run: bundle install
   - &save_bundler_cache
-    save_bundler_cache:
+    save_cache:
       key: gem-cache-v1-{{ checksum "Gemfile.lock" }}
       paths:
         - vendor/bundle
   - &restore_yarn_cache
-    restore_yarn_cache:
+    restore_cache:
       key: yarn-cache-{{ checksum "yarn.lock" }}
   - &yarn_install
     run: yarn install
   - &save_yarn_cache
-    save_yarn_cache:
+    save_cache:
       key: yarn-cache-{{ checksum "yarn.lock" }}
       paths:
         - node_modules


### PR DESCRIPTION
Addresses #82 
===========
I did a bit of a refactor on the CircleCI config alongside the cache bits.

Here are the new features:
* aliases - they're at the top. it was easier for me to remember which cache I was restoring since CircleCI's syntax _requires_ you to name the cache saving and restoration steps identically, regardless of which package manager you're using
* ~build contexts - mainly because I am used to using build contexts for runtime environment variables that I don't want to expose in the config file. you can get rid of this if it's a bit much.~
* branch filters - this enabled me to run the build scripts on a feature branch

Also, if there's no cache to restore on the first run, it doesn't fail the build.

This was a fun one! Feel free to request any further changes here. 