### PR TITLE
Workaround to install Yarn dependencies after volume mount

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,4 +6,4 @@ services:
       - .:/app
     ports:
       - "4000:4000"
-    command: "bundle exec jekyll serve --incremental --host 0.0.0.0"
+    command: sh -c "yarn install && bundle exec jekyll serve --incremental --host 0.0.0.0"


### PR DESCRIPTION
Fix #104 

I don't like this solution and I'm worried about Gemfile dependencies as well. Opening to give more context fixing the issue.