### PR TITLE
Fix jekyll's doctor command

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -9,7 +9,7 @@
     <ul class="flex text-gray-300">
       <li class="ml-8"><a href={{ "/blog.html" | prepend: site.baseurl }}>{% t menu.blog %}</a></li>
       <li class="ml-8"><a href={{ "https://community.coopdevs.org" }}>{% t menu.community %}</a></li>
-      <li class="ml-8"><a href={{ "/jobs/accountant" | prepend: site.baseurl }}>{% t menu.jobs %}</a></li>
+      <li class="ml-8"><a href={{ "/jobs" | prepend: site.baseurl }}>{% t menu.jobs %}</a></li>
     </ul>
 
     <ul class="flex ml-8 text-gray-300">

--- a/jobs.html
+++ b/jobs.html
@@ -1,7 +1,6 @@
 ---
 layout: job
 title: Tècnica en comptabilitat i analista de processos empresarials
-permalink: /jobs/accountant
 ---
 
 {% translate_file accountant.md %}


### PR DESCRIPTION
`bundle exec jekyll doctor --trace` reports an error related to the
plugin https://github.com/kurtsson/jekyll-multiple-languages-plugin that
has to do with the `permalink` param. I choose the easy way and make it
use the /jobs URL instead.

I'll see how make both work (the param and the plugin) later on.