### PR TITLE
Use a data volume to store the node_modules

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     build: .
     volumes:
       - .:/app
+      - /app/node_modules
     ports:
       - "4000:4000"
     command: "bundle exec jekyll serve --incremental --host 0.0.0.0"


### PR DESCRIPTION
Closes #104

From the docker docs:

> If you start a container which creates a new volume, as above, and the container has files or directories in the directory to be mounted (such as /app/ above), the directory’s contents are copied into the volume.

This keeps the `node_modules` that exist already in /app/ when we mount the current directory (.) into /app/.

This allows me to successfully run `docker-compose up` on a new and fresh machine. I have proof (from my old laptop I have at home) :point_down: 

```
yarn install v1.19.2                                                                                                                                                                                [17/134]
warning package.json: No license field                               
warning No license field              
[1/4] Resolving packages...                                     
[2/4] Fetching packages...                                 
info fsevents@1.2.9: The platform "linux" is incompatible with this module.
info "fsevents@1.2.9" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Building fresh packages...                                     
Done in 10.04s.                       
Removing intermediate container 481b7b1bfa38                    
 ---> 4120dfceb72d                                         
Step 6/7 : EXPOSE 4000 
 ---> Running in 4ddab5a19d86                               
Removing intermediate container 4ddab5a19d86
 ---> 0fdaa3b3f7e5                                    
Step 7/7 : CMD ["bundle", "exec", "jekyll", "serve"]   
 ---> Running in e95066dbd646                                                                                                                                                                              
Removing intermediate container e95066dbd646                                                                                                                                                               
 ---> 77063c15bdee
Successfully built 77063c15bdee
Successfully tagged coopdevsgithubio_web:latest
Recreating 24cffb17d726_coopdevsgithubio_web_1 ... done
Attaching to coopdevsgithubio_web_1
web_1  | Configuration file: /app/_config.yml
web_1  |             Source: /app
web_1  |        Destination: /app/_site
web_1  |  Incremental build: enabled
web_1  |       Generating...
web_1  | Building site for default language: "ca" to: /app/_site
web_1  | Loading translation from file /app/_i18n/ca.yml
web_1  | Browserslist: caniuse-lite is outdated. Please run next command `yarn upgrade`
web_1  | Building site for language: "es" to: /app/_site/es
web_1  | Loading translation from file /app/_i18n/es.yml
web_1  | Build complete
web_1  |                     done in 3.438 seconds.
web_1  |  Auto-regeneration: enabled for '/app'
web_1  |     Server address: http://0.0.0.0:4000/
web_1  |   Server running... press ctrl-c to stop.
web_1  |       Regenerating: 1 file(s) changed at 2020-03-05 08:48:15
web_1  |                     jobs.html
web_1  | Building site for default language: "ca" to: /app/_site
web_1  | Building site for language: "es" to: /app/_site/es
web_1  | Build complete
web_1  |                     ...done in 0.236611118 seconds.
web_1  |
web_1  |       Regenerating: 1 file(s) changed at 2020-03-05 08:48:15
web_1  |                     jobs.html
web_1  | Building site for default language: "ca" to: /app/_site
web_1  | Building site for language: "es" to: /app/_site/es
web_1  | Build complete
web_1  |                     ...done in 0.270110684 seconds.
```